### PR TITLE
Add support for processing CSV data from the Simple Health Export CSV iOS app

### DIFF
--- a/Apple2Dreem.py
+++ b/Apple2Dreem.py
@@ -238,7 +238,7 @@ def parse_datetime(input_str: str) -> datetime:
 def process_file(input_file: str, output_folder: str, from_date: datetime, to_date: datetime, time_shift_seconds: int, input_type: str, rename: bool, ):
     print(f"Processing file: {input_file}")
     
-    if input_type == 'json':
+    if input_type == 'json': # Support for "Health Auto Export - JSON+CSV" iOS App, json files are expected
 
         try:
             with open(input_file, 'r', encoding='utf-8') as f:
@@ -275,7 +275,7 @@ def process_file(input_file: str, output_folder: str, from_date: datetime, to_da
             )
             sleep_entries.append(sleep_entry)
             
-    elif input_type == 'csv':
+    elif input_type == 'csv': # Support for "Simple Health Export CSV" iOS App format, CSV files are expected to be in ZIP archives
         
         try:
             with ZipFile(input_file, mode='r') as zf:
@@ -289,10 +289,12 @@ def process_file(input_file: str, output_folder: str, from_date: datetime, to_da
                         try:
                             # The HealthExportCSV app puts a non-standard extra line at the top containing "sep=,"
                             line1 = f.readline()
-                            if line1 != 'sep=,\n':
-                                # put the line back if it's not the one we're trying to get rid of
-                                f.seek(0)
-                            
+                            if line1.startswith('sep=,'):
+                                # Skip the separator line
+                                pass
+                            else:
+                                f.seek(0)                              
+                                
                             sleep_entries = []
                             csvreader = csv.DictReader(f, delimiter=',', quotechar='"')
                             # columns: type,sourceName,sourceVersion,productType,device,startDate,endDate,value,HKTimeZone

--- a/Apple2Dreem.py
+++ b/Apple2Dreem.py
@@ -2,11 +2,13 @@ import sys
 import os
 import argparse
 import json
+import csv
 import math
 from datetime import datetime, timedelta, time
 from typing import List
 from dateutil import parser as date_parser
 from dateutil import tz
+from zoneinfo import ZoneInfo
 import glob
 
 class SleepSegment:
@@ -66,6 +68,18 @@ def map_sleep_stage(stage: str) -> str:
         "InBed": "WAKE"
     }
     return mapping.get(stage, "WAKE")
+
+def health_export_csv_map_sleep_stage(stage: str) -> str:
+    # Map stage values found in csv files to those in JSON files
+    mapping = {
+        "asleep":       "Asleep",
+        "asleepCore":   "Core",
+        "asleepDeep":   "Deep",
+        "asleepREM":    "REM",
+        "awake":        "Awake",
+        "inBed":        "InBed"
+    }
+    return mapping.get(stage, "Awake")
 
 def update_segments_with_sleep_data(segments: List[SleepSegment], sleep_data: List[SleepEntry]):
     for entry in sleep_data:
@@ -219,43 +233,92 @@ def parse_datetime(input_str: str) -> datetime:
         print(f"Invalid date format: {input_str}.")
         return None
 
-def process_file(input_file: str, output_folder: str, from_date: datetime, to_date: datetime, time_shift_seconds: int):
+def process_file(input_file: str, output_folder: str, from_date: datetime, to_date: datetime, time_shift_seconds: int, input_type: str, rename: bool, ):
     print(f"Processing file: {input_file}")
+    
+    if input_type == 'json':
 
-    try:
-        with open(input_file, 'r', encoding='utf-8') as f:
-            json_string = f.read()
-    except Exception as ex:
-        print(f"Warning: Unable to read file {input_file}. Error: {ex}")
+        try:
+            with open(input_file, 'r', encoding='utf-8') as f:
+                json_string = f.read()
+        except Exception as ex:
+            print(f"Warning: Unable to read file {input_file}. Error: {ex}")
+            return
+
+        try:
+            health_data_dict = json.loads(json_string)
+        except json.JSONDecodeError as ex:
+            print(f"Warning: Invalid JSON in file {input_file}. Error: {ex}")
+            return
+
+        if 'data' not in health_data_dict or 'metrics' not in health_data_dict['data']:
+            print(f"Warning: The file {input_file} does not contain valid health data.")
+            return
+
+        metrics_list = health_data_dict['data']['metrics']
+        if not metrics_list or 'data' not in metrics_list[0]:
+            print(f"Warning: No sleep data found in file {input_file}.")
+            return
+
+        sleep_data_list = metrics_list[0]['data']
+
+        sleep_entries = []
+        for entry in sleep_data_list:
+            sleep_entry = SleepEntry(
+                source=entry.get('source', ''),
+                qty=entry.get('qty', 0),
+                start_date=parse_iso8601(entry.get('startDate', '')),
+                value=entry.get('value', ''),
+                end_date=parse_iso8601(entry.get('endDate', '')),
+            )
+            sleep_entries.append(sleep_entry)
+            
+    elif input_type == 'csv':
+        
+        try:
+            with open(input_file, 'r', encoding='utf-8') as f:
+                
+                try:
+                    # The HealthExportCSV app puts a non-standard extra line at the top containing "sep=,"
+                    line1 = f.readline()
+                    if line1 != 'sep=,\n':
+                        # put the line back if it's not the one we're trying to get rid of
+                        f.seek(0)
+                    
+                    sleep_entries = []
+                    csvreader = csv.DictReader(f, delimiter=',', quotechar='"')
+                    # columns: type,sourceName,sourceVersion,productType,device,startDate,endDate,value,HKTimeZone
+                    for row in csvreader:
+                        time_zone = row['HKTimeZone']
+                        source = row['sourceName']
+                        start_date = parse_iso8601(row['startDate']).astimezone(ZoneInfo(time_zone))
+                        end_date = parse_iso8601(row['endDate']).astimezone(ZoneInfo(time_zone))
+                        value = health_export_csv_map_sleep_stage(row['value'])
+                        qty = (end_date - start_date).total_seconds()/3600.0
+                        sleep_entry = SleepEntry(
+                            source=source,
+                            qty=qty,
+                            start_date=start_date,
+                            value=value,
+                            end_date=end_date,
+                        )
+                        sleep_entries.append(sleep_entry)
+                
+                except Exception as ex:
+                    print(f"Warning: Unable to read contents of file {input_file}. Error: {ex}")
+                    return
+
+        except Exception as ex:
+            print(f"Warning: Unable to read file {input_file}. Error: {ex}")
+            return
+
+            
+    else:
+        
+        print(f"Error: Invalid input_type {input_type}")
         return
 
-    try:
-        health_data_dict = json.loads(json_string)
-    except json.JSONDecodeError as ex:
-        print(f"Warning: Invalid JSON in file {input_file}. Error: {ex}")
-        return
-
-    if 'data' not in health_data_dict or 'metrics' not in health_data_dict['data']:
-        print(f"Warning: The file {input_file} does not contain valid health data.")
-        return
-
-    metrics_list = health_data_dict['data']['metrics']
-    if not metrics_list or 'data' not in metrics_list[0]:
-        print(f"Warning: No sleep data found in file {input_file}.")
-        return
-
-    sleep_data_list = metrics_list[0]['data']
-
-    sleep_entries = []
-    for entry in sleep_data_list:
-        sleep_entry = SleepEntry(
-            source=entry.get('source', ''),
-            qty=entry.get('qty', 0),
-            start_date=parse_iso8601(entry.get('startDate', '')),
-            value=entry.get('value', ''),
-            end_date=parse_iso8601(entry.get('endDate', ''))
-        )
-        sleep_entries.append(sleep_entry)
+            
 
     if not validate_sleep_data(sleep_entries, input_file):
         return
@@ -305,13 +368,13 @@ def process_file(input_file: str, output_folder: str, from_date: datetime, to_da
             f"Apple2Dreem_{night_date.strftime('%Y-%m-%d')}_{segment_start_date.strftime('%H-%M')}_{segment_end_date.strftime('%H-%M')}.csv")
         process_health_data(entries, output_file, segment_start_date, segment_end_date, time_shift_seconds)
         print(f"Processed data for night of {night_date.strftime('%Y-%m-%d')} from {segment_start_date.strftime('%H:%M')} to {segment_end_date.strftime('%H:%M')}. Output saved to {output_file}")
-
-    try:
-        new_file_name = get_unique_file_name(os.path.join(os.path.dirname(input_file), "_" + os.path.basename(input_file)))
-        os.rename(input_file, new_file_name)
-        print(f"Renamed {input_file} to {new_file_name}")
-    except Exception as ex:
-        print(f"Warning: Unable to rename processed file {input_file}. Error: {ex}")
+    if rename:
+      try:
+          new_file_name = get_unique_file_name(os.path.join(os.path.dirname(input_file), "_" + os.path.basename(input_file)))
+          os.rename(input_file, new_file_name)
+          print(f"Renamed {input_file} to {new_file_name}")
+      except Exception as ex:
+          print(f"Warning: Unable to rename processed file {input_file}. Error: {ex}")
 
 def main():
     parser = argparse.ArgumentParser(description='AppleWatch2Dreem')
@@ -322,6 +385,8 @@ def main():
     parser.add_argument('-t', '--to', dest='to_date', help='Specify end date (format: yyyy-MM-dd or yyyy-MM-dd-HH:mm)')
     parser.add_argument('-l', '--filter', help='Specify input file filter (default: HealthAutoExport-*.json)', default='HealthAutoExport-*.json')
     parser.add_argument('-s', '--shift', type=int, help='Specify time shift in seconds (positive or negative)', default=0)
+    parser.add_argument('-y', '--type', help='Specify input file type: json (Health Auto Export app) or csv (Simple Health Export CSV app) (default: json)', default='json')
+    parser.add_argument('-r', '--rename', help='Specify whether to rename the input file upon completion (default: true)', default='true')
 
     args = parser.parse_args()
 
@@ -331,6 +396,8 @@ def main():
     from_date = parse_datetime(args.from_date)
     to_date = parse_datetime(args.to_date)
     time_shift_seconds = args.shift
+    input_type = args.type
+    rename = args.rename == 'true'
 
     if not output_folder:
         output_folder = input_folder
@@ -349,6 +416,10 @@ def main():
         to_date = to_date.replace(hour=11, minute=0, second=0, microsecond=0)
     if to_date.tzinfo is None:
         to_date = to_date.replace(tzinfo=tz.tzlocal())
+        
+    if not (input_type=='json' or input_type =='csv'):
+        print (f"Error: invalid type '{input_type}'; must be 'json' or 'csv'")
+        return
 
     print(f"Input folder: {input_folder}")
     print(f"Output folder: {output_folder}")
@@ -356,6 +427,8 @@ def main():
     print(f"From date: {from_date}")
     print(f"To date: {to_date}")
     print(f"Time shift: {time_shift_seconds} seconds")
+    print(f"Input type: {input_type}")
+    print(f"Rename input: {rename}")
 
     if not os.path.exists(input_folder):
         print(f"Error: Input folder '{input_folder}' does not exist.")
@@ -373,7 +446,7 @@ def main():
 
     for file in files:
         try:
-            process_file(file, output_folder, from_date, to_date, time_shift_seconds)
+            process_file(file, output_folder, from_date, to_date, time_shift_seconds, input_type, rename)
             processed_files += 1
         except Exception as ex:
             print(f"Warning: Failed to process file {file}. Error: {ex}")

--- a/README.md
+++ b/README.md
@@ -1,144 +1,228 @@
-This script can convert the sleep data from your Apple Watch to the format of the Dreem headband.
-This enables software like OSCAR to import it.
+# Apple2Dreem Script
 
-One should provide input files from the Apple Watch using the Auto Export iOS app: 
+This script can convert the sleep data from your Apple Watch to the format of the Dreem headband. This enables software like OSCAR to import it.
+
+## Input data
+
+One should provide input files from the Apple Watch using one of two iOS apps: 
+
+### Health Auto Export - JSON+CSV iOS app
+
 https://apps.apple.com/nl/app/health-auto-export-json-csv/id1115567069
 
-App Settings: 
-Select only Sleep Metrics (Sleep Analysis) for export,
-Export Format: JSON,
-Aggregate Data: False
+To use this data format, specify the ```--type json``` option to Apple2Dreem.py (default). 
 
-Apple2Dreem Script
-Description
+App Settings: 
+
+  * Select only Sleep Metrics (Sleep Analysis) for export,
+  * Export Format: JSON,
+  * Aggregate Data: False
+
+### Simple Health Export CSV
+
+https://apps.apple.com/us/app/simple-health-export-csv/id1535380115
+
+The app exports CSV files compressed into a dip file. Apple2Dreem.py processes the exported zip files directly. To use this data format, specify the ```--type csv``` option to Apple2Dreem.py.
+
+## Apple2Dreem.py Description
+
 The Apple2Dreem.py script is designed to convert sleep data exported from Apple Health (specifically from the Apple Watch) into a format compatible with Dreem, a sleep analysis platform. The script processes JSON files containing sleep metrics and generates CSV files with sleep segments and statistics.
 
-Features
-Parses Apple Health sleep data exported in JSON format.
-Groups sleep data by night, considering sleep sessions from 19:00 to 11:00 the next day.
-Handles time zones and time shifts, ensuring accurate time representation.
-Generates CSV files containing detailed sleep analysis compatible with Dreem.
-Automatically renames processed files to prevent reprocessing.
-Prerequisites
-Python 3.6 or higher
-Required Python libraries:
-python-dateutil
-Installation
-Clone or download the script to your local machine.
-Install the required libraries using pip:
-pip install python-dateutil
-Usage
+## Features
+
+  * Parses Apple Health sleep data exported in JSON format.
+  * Groups sleep data by night, considering sleep sessions from 19:00 to 11:00 the next day.
+  * Handles time zones and time shifts, ensuring accurate time representation.
+  * Generates CSV files containing detailed sleep analysis compatible with Dreem.
+  * Automatically renames processed files to prevent reprocessing (optionally disableable).
+
+## Prerequisites
+
+  * Python 3.6 or higher
+  * Required Python libraries:
+    * python-dateutil
+
+## Installation
+  * Clone or download the script to your local machine.
+  * Install the required libraries using pip:
+  * pip install python-dateutil
+
+## Usage
+
 The script can be run from the command line with various options. Below is the syntax and explanation of each option.
 
-Command Line Syntax
-python Apple2Dreem.py [options]
-Options
+## Command Line Syntax
+
+```python Apple2Dreem.py [options]```
+
+### Options
+
+```
 -i, --input
 Description: Specify the input folder containing the JSON files.
 Default: Current directory (.)
 Usage:
 
-python Apple2Dreem.py -i path/to/input_folder
+    python Apple2Dreem.py -i path/to/input_folder
+
 -o, --output
 Description: Specify the output folder where CSV files will be saved.
 Default: Same as input folder
 Usage:
 
-python Apple2Dreem.py -o path/to/output_folder
+    python Apple2Dreem.py -o path/to/output_folder
+
 -f, --from
 Description: Specify the start date and time for processing data.
 Format: yyyy-MM-dd or yyyy-MM-dd-HH:mm
 Default: Yesterday at 19:00
 Usage:
 
-python Apple2Dreem.py -f 2024-11-22
-python Apple2Dreem.py -f 2024-11-22-19:00
+    python Apple2Dreem.py -f 2024-11-22
+    python Apple2Dreem.py -f 2024-11-22-19:00
+
 -t, --to
 Description: Specify the end date and time for processing data.
 Format: yyyy-MM-dd or yyyy-MM-dd-HH:mm
 Default: Today at 11:00
 Usage:
 
-python Apple2Dreem.py -t 2024-11-23
-python Apple2Dreem.py -t 2024-11-23-11:00
+    python Apple2Dreem.py -t 2024-11-23
+    python Apple2Dreem.py -t 2024-11-23-11:00
+
 -l, --filter
 Description: Specify the input file filter (supports wildcards).
 Default: HealthAutoExport-*.json
 Usage:
 
-python Apple2Dreem.py -l "MyHealthData-*.json"
+    python Apple2Dreem.py -l "MyHealthData-*.json"
+
 -s, --shift
 Description: Specify a time shift in seconds to adjust the timestamps in the data.
 Default: 0 seconds
 Usage:
 
-python Apple2Dreem.py -s 3600  # Shift time by 1 hour forward
-python Apple2Dreem.py -s -1800 # Shift time by 30 minutes backward
+    python Apple2Dreem.py -s 3600  # Shift time by 1 hour forward
+    python Apple2Dreem.py -s -1800 # Shift time by 30 minutes backward
+
+
+-y, --type
+Description: Specify input file type: **json** (Health Auto Export app) or **csv** (Simple Health Export CSV app)
+Default: json
+Usage:
+
+    python Apple2Dreem.py -y csv
+
+-r, --rename
+Description: Specify whether to rename the input file upon completion ('true' or 'false')
+Default: true
+Usage:
+
+    python Apple2Dreem.py -r false
+
 -h, --help
 Description: Display the help message and exit.
 Usage:
 
-python Apple2Dreem.py -h
-Examples
+    python Apple2Dreem.py -h
+```
+
+## Examples
+
 Process all default JSON files in the current directory with default dates and no time shift:
 
+```
 python Apple2Dreem.py
+```
+
 Process files in a specific input folder and output to a different folder:
 
+```
 python Apple2Dreem.py -i ./input_folder -o ./output_folder
+```
+
 Process data from a specific date range with a time shift of 1 hour forward:
 
+```
 python Apple2Dreem.py -f 2024-11-22 -t 2024-11-23 -s 3600
+```
+
 Use a custom file filter to process specific files:
 
+```
 python Apple2Dreem.py -l "MySleepData-2024-*.json"
-Default Values
+```
+
+## Default Values
+
 If no options are specified, the script uses the following default values:
 
-Input folder: Current directory (.)
-Output folder: Same as input folder
-File filter: HealthAutoExport-*.json
-From date: Yesterday at 19:00 (7:00 PM)
-To date: Today at 11:00 (11:00 AM)
-Time shift: 0 seconds (no shift)
-How the Script Works
-File Selection: The script searches for JSON files in the input folder that match the specified file filter.
+  * Input folder: Current directory (.)
+  * Output folder: Same as input folder
+  * File filter: HealthAutoExport-*.json
+  * From date: Yesterday at 19:00 (7:00 PM)
+  * To date: Today at 11:00 (11:00 AM)
+  * Time shift: 0 seconds (no shift)
+  * Type: json
+  * Rename: true
 
-Data Parsing:
+## How the Script Works
 
-Reads each JSON file.
-Parses sleep data entries, converting date strings into datetime objects.
-Ensures all datetime objects are timezone-aware.
-Grouping Sleep Data:
+### File Selection 
 
-Groups sleep data entries by night, considering sessions from 19:00 to 11:00 the next day.
-Applies the specified date range (from_date and to_date).
-Processing Sleep Segments:
+The script searches for JSON or CSV.ZIP files in the input folder that match the specified file filter.
 
-Creates 30-second segments between the start and end times.
-Maps sleep stages from the data to standard stages (Light, Deep, REM, etc.).
-Updates segments with sleep stage information.
-Calculating Sleep Statistics:
+### Data Parsing*
 
-Calculates total sleep duration, sleep onset duration, durations of different sleep stages, wake after sleep onset, and number of awakenings.
-Generates a hypnogram representing sleep stages over time.
-Generating Output:
+  * Reads each JSON file.
+  * Parses sleep data entries, converting date strings into datetime objects.
+  * Ensures all datetime objects are timezone-aware.
+
+### Grouping Sleep Data:
+
+  * Groups sleep data entries by night, considering sessions from 19:00 to 11:00 the next day.
+  * Applies the specified date range (from_date and to_date).
+
+### Processing Sleep Segments:
+
+  * Creates 30-second segments between the start and end times.
+  * Maps sleep stages from the data to standard stages (Light, Deep, REM, etc.).
+  * Updates segments with sleep stage information.
+
+### Calculating Sleep Statistics:
+
+  * Calculates total sleep duration, sleep onset duration, durations of different sleep stages, wake after sleep onset, and number of awakenings.
+  * Generates a hypnogram representing sleep stages over time.
+
+### Generating Output:
 
 Writes the processed data to a CSV file in the output folder.
 The CSV file contains headers and a row with the calculated sleep statistics.
-File Management:
+
+### File Management
 
 Renames the processed JSON files by prefixing them with an underscore (_) to prevent reprocessing.
-Notes
-Time Zones: The script handles time zones by ensuring all datetime objects are timezone-aware. If the time zone information is missing, it assumes the local time zone.
-Date Formats: The script is flexible with date formats, using dateutil.parser.parse to handle various date and time representations.
-Error Handling: The script includes warnings and error messages to help identify and troubleshoot issues with data parsing or file processing.
-Troubleshooting
-Invalid Date Formats: If you receive warnings about invalid date formats, ensure that your JSON files contain date strings in a recognizable format.
-No Files Found: If the script reports that no files were found, verify that the file filter matches the filenames in the input folder.
-Permission Issues: If the script cannot read or write files, check the permissions of the input and output directories.
-Contributing
+
+## Notes
+
+**Time Zones**: The script handles time zones by ensuring all datetime objects are timezone-aware. If the time zone information is missing, it assumes the local time zone.
+
+**Date Formats**: The script is flexible with date formats, using dateutil.parser.parse to handle various date and time representations.
+
+**Error Handling**: The script includes warnings and error messages to help identify and troubleshoot issues with data parsing or file processing.
+
+## Troubleshooting
+
+**Invalid Date Formats**: If you receive warnings about invalid date formats, ensure that your JSON files contain date strings in a recognizable format.
+
+**No Files Found**: If the script reports that no files were found, verify that the file filter matches the filenames in the input folder.
+
+**Permission Issues**: If the script cannot read or write files, check the permissions of the input and output directories.
+
+## Contributing
+
 If you wish to contribute to the script or report issues, please feel free to submit pull requests or open issues on the repository where this script is hosted.
 
-License
+## License
+
 This script is provided as-is without any warranty. Use it at your own risk. The author is not responsible for any damage or data loss resulting from its use.


### PR DESCRIPTION
I'm very grateful for the script. Thank you for making it available.

My preferred Apple Health export app is "Simple Health Export CSV," mostly because it doesn't require a subscription. I've added support for the format it exports (a zipped CSV). Using defaults or the ```--type json``` option, the script still imports JSON from the original "Health Auto Export - JSON+CSV" app. With the ```--type csv``` option, it imports the zipped CSV files from the new app. 

To test, I used both apps and their respective formats. Apple2Dreem.py yielded identical output files from the JSON and CSV.

The code is a little messier than I'd like but I wanted to get it out there for others to use. A useful refactoring would be to create an abstract base class for reading source files and derived classes that implement each supported input format. That would make it easier to add new formats. However, it might be a while before I could devote any time to implementing that.

I did tidy up the README markdown as I updated the usage instructions. I hope the formatting is acceptable.
 
I also added an option to not rename the input files after processing as that suits my workflow better. The default is still to rename.